### PR TITLE
Use Seed data in AdvocatesTable

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+DATABASE_URL=postgres://postgres:password@localhost:5432/solaceassignment

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,10 +1,19 @@
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
 //import { advocateData } from "../../../db/seed/advocates";
+import { NextRequest } from "next/server";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const limit = parseInt(searchParams.get("limit") || ("20"));
+  const offset = parseInt(searchParams.get("offset") || "0");
+  
   // Uncomment this line to use a database
-  const data = await db.select().from(advocates);
+  const data = await db
+    .select()
+    .from(advocates)
+    .limit(limit)
+    .offset(offset);
 
   //const data = advocateData; // no longer needed. using live DB;
 

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,12 @@
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+//import { advocateData } from "../../../db/seed/advocates";
 
 export async function GET() {
   // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+  const data = await db.select().from(advocates);
 
-  const data = advocateData;
+  //const data = advocateData; // no longer needed. using live DB;
 
   return Response.json({ data });
 }

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -1,9 +1,10 @@
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+import db from "@/db";
+import { advocates } from "@/db/schema";
+import { advocateData } from "@/db/seed/advocates";
 
 export async function POST() {
+  // Delete all rows from the table
+  await db.delete(advocates);
   const records = await db.insert(advocates).values(advocateData).returning();
-
   return Response.json({ advocates: records });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,18 +11,15 @@ export default function Home() {
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedTerm, setDebouncedTerm] = useState(searchTerm);
   const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+  const [pageSize] = useState(10);
 
   useEffect(() => {
     setLoading(true);
-    fetch("/api/advocates")
+    fetch(`/api/advocates?limit=${pageSize}&offset=${page * pageSize}`)
       .then((response) => {
         response.json()
       .then((jsonResponse) => {
-        jsonResponse.data.forEach((advocate: any) => {
-          console.log(
-            `ID: ${advocate.id} | ${advocate.firstName} ${advocate.lastName} | ${advocate.specialties.length} specialties`
-          );
-        });
         setAdvocates(jsonResponse.data);
         setFilteredAdvocates(jsonResponse.data);
         setLoading(false);
@@ -32,7 +29,7 @@ export default function Home() {
         setLoading(false);
       })
     });
-  }, []);
+  }, [page, pageSize]);
 
   //debounce effect
   useEffect(() => {
@@ -76,10 +73,27 @@ export default function Home() {
       {loading ? (
         <p>Loading advocates that match your search term</p>
       ) : filteredAdvocates.length > 0 ? (
-        <AdvocatesTable 
-          advocates={filteredAdvocates} 
-          searchTerm={searchTerm}
-        />
+        <>
+          <AdvocatesTable 
+            advocates={filteredAdvocates} 
+            searchTerm={searchTerm}
+          />
+          <div className="flex justify-center mt-6 gap-4">
+            <button
+              disabled={page === 0}
+              onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+              className="bg-gray-200 hover:bg-[#265b4e]/50 px-4 py-2 rounded-xl disabled:opacity-50"
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => setPage((prev) => prev + 1)}
+              className="bg-[#265b4e] hover:bg-[#1D4339] text-white px-4 py-2 rounded-xl"
+            >
+              Next
+            </button>
+          </div>
+        </>
       ) : (
         <p>No advocates found.</p>
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,8 +14,15 @@ export default function Home() {
 
   useEffect(() => {
     setLoading(true);
-    fetch("/api/advocates").then((response) => {
-      response.json().then((jsonResponse) => {
+    fetch("/api/advocates")
+      .then((response) => {
+        response.json()
+      .then((jsonResponse) => {
+        jsonResponse.data.forEach((advocate: any) => {
+          console.log(
+            `ID: ${advocate.id} | ${advocate.firstName} ${advocate.lastName} | ${advocate.specialties.length} specialties`
+          );
+        });
         setAdvocates(jsonResponse.data);
         setFilteredAdvocates(jsonResponse.data);
         setLoading(false);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,12 +3,7 @@ import postgres from "postgres";
 
 const setup = () => {
   if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
+    throw new Error("DATABASE_URL is not set");
   }
 
   // for query purposes

--- a/src/db/seed/advocates.ts
+++ b/src/db/seed/advocates.ts
@@ -1,5 +1,5 @@
-import db from "..";
-import { advocates } from "../schema";
+// import db from "..";
+// import { advocates } from "../schema";
 
 const specialties = [
   "Bipolar",
@@ -30,11 +30,16 @@ const specialties = [
   "Domestic abuse",
 ];
 
-const randomSpecialty = () => {
-  const random1 = Math.floor(Math.random() * 24);
-  const random2 = Math.floor(Math.random() * (24 - random1)) + random1 + 1;
+const randomSpecialty = (): string[] => {
+  const first = specialties[Math.floor(Math.random() * specialties.length)];
+  let second = specialties[Math.floor(Math.random() * specialties.length)];
 
-  return [random1, random2];
+  // Ensure they specialties are not the same
+  while (second === first) {
+    second = specialties[Math.floor(Math.random() * specialties.length)];
+  }
+
+  return [first, second];
 };
 
 const advocateData = [
@@ -43,7 +48,7 @@ const advocateData = [
     lastName: "Doe",
     city: "New York",
     degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 10,
     phoneNumber: 5551234567,
   },
@@ -52,7 +57,7 @@ const advocateData = [
     lastName: "Smith",
     city: "Los Angeles",
     degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 8,
     phoneNumber: 5559876543,
   },
@@ -61,7 +66,7 @@ const advocateData = [
     lastName: "Johnson",
     city: "Chicago",
     degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 5,
     phoneNumber: 5554567890,
   },
@@ -70,7 +75,7 @@ const advocateData = [
     lastName: "Brown",
     city: "Houston",
     degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 12,
     phoneNumber: 5556543210,
   },
@@ -79,7 +84,7 @@ const advocateData = [
     lastName: "Davis",
     city: "Phoenix",
     degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 7,
     phoneNumber: 5553210987,
   },
@@ -88,7 +93,7 @@ const advocateData = [
     lastName: "Martinez",
     city: "Philadelphia",
     degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 9,
     phoneNumber: 5557890123,
   },
@@ -97,7 +102,7 @@ const advocateData = [
     lastName: "Taylor",
     city: "San Antonio",
     degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 11,
     phoneNumber: 5554561234,
   },
@@ -106,7 +111,7 @@ const advocateData = [
     lastName: "Harris",
     city: "San Diego",
     degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 6,
     phoneNumber: 5557896543,
   },
@@ -115,7 +120,7 @@ const advocateData = [
     lastName: "Clark",
     city: "Dallas",
     degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 4,
     phoneNumber: 5550123456,
   },
@@ -124,7 +129,7 @@ const advocateData = [
     lastName: "Lewis",
     city: "San Jose",
     degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 13,
     phoneNumber: 5553217654,
   },
@@ -133,7 +138,7 @@ const advocateData = [
     lastName: "Lee",
     city: "Austin",
     degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 10,
     phoneNumber: 5551238765,
   },
@@ -142,7 +147,7 @@ const advocateData = [
     lastName: "King",
     city: "Jacksonville",
     degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 5,
     phoneNumber: 5556540987,
   },
@@ -151,7 +156,7 @@ const advocateData = [
     lastName: "Green",
     city: "San Francisco",
     degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 14,
     phoneNumber: 5559873456,
   },
@@ -160,7 +165,7 @@ const advocateData = [
     lastName: "Walker",
     city: "Columbus",
     degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 9,
     phoneNumber: 5556781234,
   },
@@ -169,7 +174,7 @@ const advocateData = [
     lastName: "Hall",
     city: "Fort Worth",
     degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
+    specialties: randomSpecialty(),
     yearsOfExperience: 3,
     phoneNumber: 5559872345,
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## ✨ Summary

This PR completes the task of seeding advocate data into our Postgres database and making sure each advocate only has **2 specialties**, as expected on the frontend.

## What’s included:

- **Seed script setup**:
  - Created a `/api/seed` route that clears out the current advocates and adds 15 fresh ones.
  - Each advocate gets 2 random specialties pulled from a predefined list.
  - Avoids duplicates by checking for uniqueness in the pair.

- **Updated `db/seed/advocates.ts`**:
  - Used the pre-defined advocate objects (with realistic names, degrees, cities, etc.) to populate the database.
  - Ensured no duplicates and validated output using console logs and database inspection.

- **Pagination**:
  - Added basic pagination and pagination controls to `page.tsx` to support scaling to a large number of advocate records
  - Users now fetch only a limited number of advocates at a time using `?limit` and `?offset` query parameters
  - Pagination state (`page`, `pageSize`) is tracked in React and passed to the `/api/advocates` call

- **Fixed TypeScript issues**:
  - Cleaned up the DB setup so `delete()` and `insert()` work without throwing errors.
  - Removed fallback return types in `db/index.ts` to avoid confusion during local development.

- **Tested on the frontend**:
  - Advocates are showing up as expected.
  - Everyone has exactly **2 specialties**.
  - Search and filter still work correctly.

## 🧪 How to Test

1. Send a `POST` request to `/api/seed` to reset and seed the DB.
2. Visit the homepage and confirm:
   - No duplicate advocate entries exist.
   - Each advocate has exactly 2 specialties.
   - Search and filtering work as expected.
