### PR TITLE
OPTIONAL: Expanded table row

### DIFF
--- a/src/components/AdvocatesTable.tsx
+++ b/src/components/AdvocatesTable.tsx
@@ -5,10 +5,11 @@ import {
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
+  getExpandedRowModel,
   useReactTable,
   SortingState,
 } from '@tanstack/react-table'
-import { useState } from 'react'
+import React, { useState } from 'react'
 
 export type Advocate = {
   firstName: string;
@@ -45,7 +46,8 @@ function highlightMatch(text: string | number, term: string) {
 }
 
 export function AdvocatesTable({ advocates, searchTerm }: Props) {
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [expanded, setExpanded] = useState({});
 
   const columns: ColumnDef<Advocate>[] = [
     {
@@ -97,10 +99,16 @@ export function AdvocatesTable({ advocates, searchTerm }: Props) {
   const table = useReactTable({
     data: advocates,
     columns,
-    state: { sorting },
+    state: { 
+      sorting,
+      expanded, 
+  },
     onSortingChange: setSorting,
+    onExpandedChange: setExpanded,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getRowCanExpand: () => true,
   })
 
   return (
@@ -143,13 +151,32 @@ export function AdvocatesTable({ advocates, searchTerm }: Props) {
         </thead>
         <tbody>
           {table.getRowModel().rows.map((row) => (
-            <tr key={row.id} className="border-t border-gray-200 hover:bg-[#285e50]/20">
-              {row.getVisibleCells().map((cell) => (
-                <td key={cell.id} className="px-4 py-2 border border-gray-300">
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
+            <React.Fragment key={row.id}>
+              <tr 
+                key={row.id} 
+                className="border-t border-gray-200 hover:bg-[#285e50]/20"
+                onClick={() => row.toggleExpanded()}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} className="px-4 py-2 border border-gray-300">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+
+              {row.getIsExpanded() && (
+                // opportunity for a separate component(s) here to show users additional relevant content.
+                <tr className="bg-white">
+                  <td colSpan={columns.length} className="p-4">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                      <div className="border p-4 rounded-md shadow text-center">More information here.</div>
+                      <div className="border p-4 rounded-md shadow text-center">More information here.</div>
+                      <div className="border p-4 rounded-md shadow text-center">More information here.</div>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
           ))}
         </tbody>
       </table>


### PR DESCRIPTION
## ✨ Add Expandable Rows to Advocates Table

This PR introduces **expandable rows** to the desktop table view using TanStack Table’s built-in `getExpandedRowModel()` functionality.

## Why this matters:

While not required by the original scope, this enhancement shows how the current TanStack table implementation can be extended to support **rich, per-row expansion**. This type of feature is useful for showcasing additional advocate details without navigating away from or cluttering up the main table.

## What’s included:

- Integrated `getExpandedRowModel()` and `expanded` state tracking via `useReactTable`
- Configured each table row to be expandable by clicking it
- Rendered an additional row with **three placeholder cards** (`More information here`) beneath any expanded row that is a simple example of where things like availability, reviews, or other details could go.

## How to test:

1. Go to the Advocates table view (desktop).
2. Click on any row — it should expand downward to reveal the three placeholder cards.
3. Click the row again to collapse it.

### 🚀 Notes

This implementation lays the groundwork for more advanced interactivity, and is intentionally lightweight. Actual expanded content could later include actions, schedules, or an advocate profile preview.
